### PR TITLE
Macroquad loop

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -11,6 +11,12 @@ pub struct Cell {
     state: CellState,
 }
 
+impl Default for Cell {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Cell {
     pub fn new() -> Self {
         Cell {

--- a/src/game.rs
+++ b/src/game.rs
@@ -86,6 +86,11 @@ impl Game {
         (self.grid.len(), self.grid[0].len())
     }
 
+    /// Returns a boolean indicating if the cell in the position is alive or not
+    pub fn is_alive(&self, pos: Position) -> bool {
+        self.alive_cells().contains(&pos)
+    }
+
     /// Updates the internal state to represent the next step in the game according to the
     /// following rules:
     /// - Any live cell with fewer than two live neighbours dies, as if caused by underpopulation.
@@ -123,6 +128,8 @@ impl Game {
         !cell.is_alive() && live_neighbors == 3
     }
 
+    // Returns the ammount of live neighbors of a certain position, used to decide wether a cell
+    // lives or dies when next() is called
     fn live_neighbors(&self, position: Position) -> usize {
         let directions = [
             (-1, -1),
@@ -134,8 +141,8 @@ impl Game {
             (1, 0),
             (1, 1),
         ];
-        let width = self.grid[0].len() as isize;
-        let height = self.grid.len() as isize;
+        let height = self.dimensions().0 as isize;
+        let width = self.dimensions().1 as isize;
 
         let (row, column) = position;
         let mut live_neighbors = 0;
@@ -154,10 +161,11 @@ impl Game {
 
     // Internal function to check if a Position is in bounds, returns error otherwise
     fn check_in_bounds(&self, pos: Position) -> Result<(), GameError> {
-        if !Self::in_bounds(pos.0, pos.1, self.grid.len(), self.grid[0].len()) {
+        let (height, width) = self.dimensions();
+        if !Self::in_bounds(pos.0, pos.1, height, width) {
             Err(GameError::OutOfBoundsGridAccess(
                 (pos.0, pos.1),
-                (self.grid.len(), self.grid[0].len()),
+                (height, width),
             ))
         } else {
             Ok(())

--- a/src/game.rs
+++ b/src/game.rs
@@ -69,7 +69,7 @@ impl Game {
     }
 
     /// Gives life to a list of cells
-    fn give_life_list(&mut self, list: &[Position]) -> Result<(), GameError> {
+    pub fn give_life_list(&mut self, list: &[Position]) -> Result<(), GameError> {
         for &pos in list.iter() {
             self.give_life(pos)?;
         }

--- a/src/game.rs
+++ b/src/game.rs
@@ -16,8 +16,9 @@ pub struct Game {
 impl Game {
     /// Initializes a grid of height dimensions.0 and height dimensions.1
     pub fn of_size(dimensions: Position) -> Self {
+        let (height, width) = dimensions;
         Game {
-            grid: vec![vec![Cell::new(); dimensions.0]; dimensions.1],
+            grid: vec![vec![Cell::new(); width]; height],
             alive_cells: HashSet::new(),
         }
     }

--- a/src/game.rs
+++ b/src/game.rs
@@ -307,7 +307,7 @@ mod tests {
         game.next();
 
         // The single live cell should die due to underpopulation
-        assert!(!game.grid[1][1].is_alive());
+        assert!(!game.is_alive((1, 1)));
     }
 
     #[test]
@@ -321,12 +321,12 @@ mod tests {
         game.next();
 
         // The three cells should rearrange to a vertical line
-        assert!(game.grid[0][1].is_alive());
-        assert!(game.grid[1][1].is_alive());
-        assert!(game.grid[2][1].is_alive());
+        assert!(game.is_alive((0, 1)));
+        assert!(game.is_alive((1, 1)));
+        assert!(game.is_alive((2, 1)));
 
-        assert!(!game.grid[1][0].is_alive());
-        assert!(!game.grid[1][2].is_alive());
+        assert!(!game.is_alive((1, 0)));
+        assert!(!game.is_alive((1, 2)));
     }
 
     #[test]
@@ -340,7 +340,7 @@ mod tests {
         game.next();
 
         // The cell at (1, 1) should die due to overpopulation
-        assert!(!game.grid[1][1].is_alive());
+        assert!(!game.is_alive((1, 1)));
     }
 
     #[test]
@@ -354,7 +354,7 @@ mod tests {
         game.next();
 
         // The dead cell at (0, 0) should come to life due to reproduction
-        assert!(game.grid[0][0].is_alive());
+        assert!(game.is_alive((0, 0)));
     }
 
     #[test]
@@ -368,12 +368,12 @@ mod tests {
         game.next();
 
         // The blinker should turn into a horizontal line
-        assert!(game.grid[2][1].is_alive());
-        assert!(game.grid[2][2].is_alive());
-        assert!(game.grid[2][3].is_alive());
+        assert!(game.is_alive((2, 1)));
+        assert!(game.is_alive((2, 2)));
+        assert!(game.is_alive((2, 3)));
 
-        assert!(!game.grid[1][2].is_alive());
-        assert!(!game.grid[3][2].is_alive());
+        assert!(!game.is_alive((1, 2)));
+        assert!(!game.is_alive((3, 2)));
     }
 
     #[test]
@@ -385,29 +385,29 @@ mod tests {
 
         // First step: The blinker should turn into a horizontal line
         game.next();
-        assert!(game.grid[2][1].is_alive());
-        assert!(game.grid[2][2].is_alive());
-        assert!(game.grid[2][3].is_alive());
+        assert!(game.is_alive((2, 1)));
+        assert!(game.is_alive((2, 2)));
+        assert!(game.is_alive((2, 3)));
 
-        assert!(!game.grid[1][2].is_alive());
-        assert!(!game.grid[3][2].is_alive());
+        assert!(!game.is_alive((1, 2)));
+        assert!(!game.is_alive((3, 2)));
 
         // Second step: The blinker should return to a vertical line
         game.next();
-        assert!(game.grid[1][2].is_alive());
-        assert!(game.grid[2][2].is_alive());
-        assert!(game.grid[3][2].is_alive());
+        assert!(game.is_alive((1, 2)));
+        assert!(game.is_alive((2, 2)));
+        assert!(game.is_alive((3, 2)));
 
-        assert!(!game.grid[2][1].is_alive());
-        assert!(!game.grid[2][3].is_alive());
+        assert!(!game.is_alive((2, 1)));
+        assert!(!game.is_alive((2, 3)));
 
         // Third step: The blinker should turn into a horizontal line again
         game.next();
-        assert!(game.grid[2][1].is_alive());
-        assert!(game.grid[2][2].is_alive());
-        assert!(game.grid[2][3].is_alive());
+        assert!(game.is_alive((2, 1)));
+        assert!(game.is_alive((2, 2)));
+        assert!(game.is_alive((2, 3)));
 
-        assert!(!game.grid[1][2].is_alive());
-        assert!(!game.grid[3][2].is_alive());
+        assert!(!game.is_alive((1, 2)));
+        assert!(!game.is_alive((3, 2)));
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -28,7 +28,10 @@ impl Game {
         for (cell_i, cell_j) in cells.iter() {
             //Return error if the cell position is out of bounds
             if !Self::in_bounds(*cell_i, *cell_j, width, height) {
-                return Err(GameError::OutOfBoundsGridAccess((*cell_i, *cell_j)));
+                return Err(GameError::OutOfBoundsGridAccess(
+                    (*cell_i, *cell_j),
+                    dimensions,
+                ));
             }
             //Otherwise, give life to the cell and return OK
             grid[*cell_i][*cell_j].give_life();
@@ -36,6 +39,16 @@ impl Game {
         let alive_cells = cells.clone();
 
         Ok(Game { grid, alive_cells })
+    }
+
+    //// Returns the vector of alive cells at the current iteration
+    pub fn alive_cells(&self) -> &Vec<Position> {
+        &self.alive_cells
+    }
+
+    /// Returns the width and height of the grid.
+    pub fn dimensions(&self) -> Position {
+        (self.grid.len(), self.grid[0].len())
     }
 
     /// Updates the internal state to represent the next step in the game according to the

--- a/src/game.rs
+++ b/src/game.rs
@@ -41,17 +41,28 @@ impl Game {
         Ok(Game { grid, alive_cells })
     }
 
-    pub fn toggle_cell(&mut self, pos: (usize, usize)) {
+    /// Kills the cell if it's alive, gives life to it if it's dead.
+    pub fn toggle_cell(&mut self, pos: (usize, usize)) -> Result<(), GameError> {
+        if !Self::in_bounds(pos.0, pos.1, self.grid.len(), self.grid[0].len()) {
+            return Err(GameError::OutOfBoundsGridAccess(
+                (pos.0, pos.1),
+                (self.grid.len(), self.grid[0].len()),
+            ));
+        }
+
         let (i, j) = pos;
+
         let cell = &mut self.grid[i][j];
         if cell.is_alive() {
             cell.kill();
             if let Some(index) = self.alive_cells.iter().position(|value| *value == pos) {
                 self.alive_cells.swap_remove(index);
             }
+            return Ok(());
         } else {
             cell.give_life();
             self.alive_cells.push(pos);
+            return Ok(());
         }
     }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -76,6 +76,12 @@ impl Game {
         Ok(())
     }
 
+    pub fn genocide(&mut self) {
+        for pos in self.alive_cells().clone() {
+            self.kill(pos)
+                .expect("Shouldn't panic because all alive_cells should be in-bounds")
+        }
+    }
     /// Returns the vector of alive cells at the current iteration
     pub fn alive_cells(&self) -> &HashSet<Position> {
         &self.alive_cells

--- a/src/game.rs
+++ b/src/game.rs
@@ -53,15 +53,21 @@ impl Game {
         let (i, j) = pos;
 
         let cell = &mut self.grid[i][j];
+
+        // Kills the cell, if it's on self.alive_cells, remove it.
         if cell.is_alive() {
             cell.kill();
             if let Some(index) = self.alive_cells.iter().position(|value| *value == pos) {
                 self.alive_cells.swap_remove(index);
             }
             return Ok(());
+
+        //Give life to the cell, if it's not on self.alive_cells, add it.
         } else {
             cell.give_life();
-            self.alive_cells.push(pos);
+            if !self.alive_cells.contains(&pos) {
+                self.alive_cells.push(pos)
+            };
             return Ok(());
         }
     }

--- a/src/game.rs
+++ b/src/game.rs
@@ -25,7 +25,7 @@ impl Game {
     /// Initializes a game with set size and already alive cells
     pub fn from_size_and_cells(
         dimensions: Position,
-        cells: &Vec<Position>,
+        cells: &[Position],
     ) -> Result<Self, GameError> {
         let mut game = Game::of_size(dimensions);
         game.give_life_list(cells)?;
@@ -64,7 +64,7 @@ impl Game {
     }
 
     /// Kills a list of cells
-    pub fn kill_list(&mut self, list: &Vec<Position>) -> Result<(), GameError> {
+    pub fn kill_list(&mut self, list: &[Position]) -> Result<(), GameError> {
         for &pos in list.iter() {
             self.kill(pos)?;
         }
@@ -72,7 +72,7 @@ impl Game {
     }
 
     /// Gives life to a list of cells
-    fn give_life_list(&mut self, list: &Vec<Position>) -> Result<(), GameError> {
+    fn give_life_list(&mut self, list: &[Position]) -> Result<(), GameError> {
         for &pos in list.iter() {
             self.give_life(pos)?;
         }
@@ -120,7 +120,7 @@ impl Game {
 
     // Function to determine if a live cell should die
     fn should_die(&self, cell: &Cell, live_neighbors: usize) -> bool {
-        cell.is_alive() && (live_neighbors < 2 || live_neighbors > 3)
+        cell.is_alive() && !(2..=3).contains(&live_neighbors)
     }
 
     // Function to determine if a dead cell should come to life
@@ -129,7 +129,7 @@ impl Game {
     }
 
     fn live_neighbors(&self, position: Position) -> usize {
-        let directions = vec![
+        let directions = [
             (-1, -1),
             (-1, 0),
             (-1, 1),
@@ -160,12 +160,12 @@ impl Game {
     // Internal function to check if a Position is in bounds, returns error otherwise
     fn check_in_bounds(&self, pos: Position) -> Result<(), GameError> {
         if !Self::in_bounds(pos.0, pos.1, self.grid.len(), self.grid[0].len()) {
-            return Err(GameError::OutOfBoundsGridAccess(
+            Err(GameError::OutOfBoundsGridAccess(
                 (pos.0, pos.1),
                 (self.grid.len(), self.grid[0].len()),
-            ));
+            ))
         } else {
-            return Ok(());
+            Ok(())
         }
     }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -22,19 +22,19 @@ impl Game {
     /// - An instance of Game with size `dimensions` and all cells in `living_cells` alive.
     /// - An error if `cells` contains out of bound positions with respect to `dimensions`.
     pub fn from_cells(dimensions: Position, cells: &Vec<Position>) -> Result<Self, GameError> {
-        let (width, height) = dimensions;
-        let mut grid = vec![vec![Cell::new(); width]; height];
+        let (rows, columns) = dimensions;
+        let mut grid = vec![vec![Cell::new(); columns]; rows];
 
-        for (cell_i, cell_j) in cells.iter() {
+        for (cell_row, cell_column) in cells.iter() {
             //Return error if the cell position is out of bounds
-            if !Self::in_bounds(*cell_i, *cell_j, width, height) {
+            if !Self::in_bounds(*cell_row, *cell_column, rows, columns) {
                 return Err(GameError::OutOfBoundsGridAccess(
-                    (*cell_i, *cell_j),
+                    (*cell_row, *cell_column),
                     dimensions,
                 ));
             }
             //Otherwise, give life to the cell and return OK
-            grid[*cell_i][*cell_j].give_life();
+            grid[*cell_row][*cell_column].give_life();
         }
         let alive_cells = cells.clone();
 
@@ -130,14 +130,14 @@ impl Game {
         let width = self.grid[0].len() as isize;
         let height = self.grid.len() as isize;
 
-        let (pos_i, pos_j) = position;
+        let (row, column) = position;
         let mut live_neighbors = 0;
         for &(dir_i, dir_j) in directions.iter() {
-            let neighbor_i = pos_i as isize + dir_i;
-            let neighbor_j = pos_j as isize + dir_j;
+            let neighbor_row = row as isize + dir_i;
+            let neighbor_column = column as isize + dir_j;
 
-            if Self::in_bounds(neighbor_i, neighbor_j, width, height)
-                && self.grid[neighbor_i as usize][neighbor_j as usize].is_alive()
+            if Self::in_bounds(neighbor_row, neighbor_column, height, width)
+                && self.grid[neighbor_row as usize][neighbor_column as usize].is_alive()
             {
                 live_neighbors += 1;
             }
@@ -145,11 +145,11 @@ impl Game {
         live_neighbors
     }
 
-    fn in_bounds<T>(i: T, j: T, w: T, h: T) -> bool
+    fn in_bounds<T>(row: T, column: T, height: T, width: T) -> bool
     where
         T: Num + PartialOrd,
     {
-        i >= T::zero() && j >= T::zero() && i < h && j < w
+        row >= T::zero() && column >= T::zero() && row < height && column < width
     }
 }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -2,7 +2,7 @@ use crate::cell::Cell;
 use crate::game_error::GameError;
 use num::traits::Num;
 use std::cmp::PartialOrd;
-
+use std::collections::HashSet;
 pub type Position = (usize, usize);
 
 ///Represents an instance of the Game of Life, it's generated with an initial state of living
@@ -10,7 +10,7 @@ pub type Position = (usize, usize);
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Game {
     grid: Vec<Vec<Cell>>,
-    alive_cells: Vec<Position>,
+    alive_cells: HashSet<Position>,
 }
 
 impl Game {
@@ -18,7 +18,7 @@ impl Game {
     pub fn of_size(dimensions: Position) -> Self {
         Game {
             grid: vec![vec![Cell::new(); dimensions.0]; dimensions.1],
-            alive_cells: vec![],
+            alive_cells: HashSet::new(),
         }
     }
 
@@ -46,9 +46,7 @@ impl Game {
         self.check_in_bounds(pos)?;
         let cell = &mut self.grid[pos.0][pos.1];
         cell.kill();
-        if let Some(index) = self.alive_cells.iter().position(|value| *value == pos) {
-            self.alive_cells.swap_remove(index);
-        }
+        self.alive_cells.remove(&pos);
         Ok(())
     }
 
@@ -57,9 +55,7 @@ impl Game {
         self.check_in_bounds(pos)?;
         let cell = &mut self.grid[pos.0][pos.1];
         cell.give_life();
-        if !self.alive_cells.contains(&pos) {
-            self.alive_cells.push(pos)
-        }
+        self.alive_cells.insert(pos);
         Ok(())
     }
 
@@ -80,7 +76,7 @@ impl Game {
     }
 
     /// Returns the vector of alive cells at the current iteration
-    pub fn alive_cells(&self) -> &Vec<Position> {
+    pub fn alive_cells(&self) -> &HashSet<Position> {
         &self.alive_cells
     }
 
@@ -114,8 +110,6 @@ impl Game {
 
         let _ = self.kill_list(&to_die);
         let _ = self.give_life_list(&to_live);
-
-        self.alive_cells = to_live;
     }
 
     // Function to determine if a live cell should die
@@ -192,7 +186,10 @@ mod tests {
         let mut grid = vec![vec![Cell::new(); 5]; 5];
         grid[1][1].give_life();
         grid[2][2].give_life();
-        let game_2 = Game { grid, alive_cells };
+        let game_2 = Game {
+            grid,
+            alive_cells: HashSet::from_iter(alive_cells),
+        };
 
         assert_eq!(game_1, game_2)
     }
@@ -205,7 +202,10 @@ mod tests {
         let mut grid = vec![vec![Cell::new(); 5]; 5];
         grid[1][1].give_life();
         grid[2][2].give_life();
-        let game_2 = Game { grid, alive_cells };
+        let game_2 = Game {
+            grid,
+            alive_cells: HashSet::from_iter(alive_cells),
+        };
 
         assert_eq!(game_1, game_2)
     }

--- a/src/game.rs
+++ b/src/game.rs
@@ -41,6 +41,20 @@ impl Game {
         Ok(Game { grid, alive_cells })
     }
 
+    pub fn toggle_cell(&mut self, pos: (usize, usize)) {
+        let (i, j) = pos;
+        let cell = &mut self.grid[i][j];
+        if cell.is_alive() {
+            cell.kill();
+            if let Some(index) = self.alive_cells.iter().position(|value| *value == pos) {
+                self.alive_cells.swap_remove(index);
+            }
+        } else {
+            cell.give_life();
+            self.alive_cells.push(pos);
+        }
+    }
+
     //// Returns the vector of alive cells at the current iteration
     pub fn alive_cells(&self) -> &Vec<Position> {
         &self.alive_cells

--- a/src/game_error.rs
+++ b/src/game_error.rs
@@ -3,7 +3,7 @@ use std::{error::Error, fmt};
 
 #[derive(Debug)]
 pub enum GameError {
-    OutOfBoundsGridAccess(Position),
+    OutOfBoundsGridAccess(Position, Position),
 }
 
 impl Error for GameError {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,59 +13,63 @@ async fn main() {
     // Initialize the game
     let mut game = Game::of_size((width, height));
 
-    // Define grid parameters
-    let horizontal_lines = height as i32;
-    let vertical_lines = width as i32;
-
     let mut running = false;
 
     loop {
         clear_background(WHITE);
 
-        // Draw horizontal lines
-        for i in 0..=horizontal_lines {
-            let y = i as f32 * grid_size;
-            draw_line(0.0, y, screen_width, y, 1.0, BLACK);
-        }
-
-        // Draw vertical lines
-        for i in 0..=vertical_lines {
-            let x = i as f32 * grid_size;
-            draw_line(x, 0.0, x, screen_height, 1.0, BLACK);
-        }
-
-        // Paint cells based on the game state
-        for cell in game.alive_cells() {
-            let x = cell.0 as f32 * grid_size;
-            let y = cell.1 as f32 * grid_size;
-            draw_rectangle(x, y, grid_size, grid_size, BLACK);
-        }
-
-        // Handle mouse input
-        if is_mouse_button_pressed(MouseButton::Left) {
-            let mouse_position = mouse_position();
-            let cell_x = (mouse_position.0 / grid_size).floor() as usize;
-            let cell_y = (mouse_position.1 / grid_size).floor() as usize;
-            if cell_x < width && cell_y < height {
-                game.toggle_cell((cell_x, cell_y))
-                    .expect("Error toggling cell");
-            }
-        }
-        // Handle buttons
-        if is_key_pressed(KeyCode::Space) {
-            running = !running;
-        }
+        draw_grid(screen_width, screen_height, grid_size, width, height);
+        draw_cells(&game, grid_size);
+        handle_input(&mut game, grid_size, width, height, &mut running);
 
         if !running {
             draw_text("Click to toggle cells", 10.0, 20.0, 20.0, BLACK);
             draw_text("Spacebar to start/pause", 10.0, 40.0, 20.0, BLACK);
-            if is_key_pressed(KeyCode::Space) {
-                game.next();
-            }
         } else {
             game.next();
         }
 
         next_frame().await;
+    }
+}
+
+fn draw_grid(screen_width: f32, screen_height: f32, grid_size: f32, width: usize, height: usize) {
+    // Draw horizontal lines
+    for i in 0..=height as i32 {
+        let y = i as f32 * grid_size;
+        draw_line(0.0, y, screen_width, y, 1.0, BLACK);
+    }
+
+    // Draw vertical lines
+    for i in 0..=width as i32 {
+        let x = i as f32 * grid_size;
+        draw_line(x, 0.0, x, screen_height, 1.0, BLACK);
+    }
+}
+
+fn draw_cells(game: &Game, grid_size: f32) {
+    // Paint cells based on the game state
+    for cell in game.alive_cells() {
+        let x = cell.0 as f32 * grid_size;
+        let y = cell.1 as f32 * grid_size;
+        draw_rectangle(x, y, grid_size, grid_size, BLACK);
+    }
+}
+
+fn handle_input(game: &mut Game, grid_size: f32, width: usize, height: usize, running: &mut bool) {
+    // Handle mouse input
+    if is_mouse_button_pressed(MouseButton::Left) {
+        let mouse_position = mouse_position();
+        let cell_x = (mouse_position.0 / grid_size).floor() as usize;
+        let cell_y = (mouse_position.1 / grid_size).floor() as usize;
+        if cell_x < width && cell_y < height {
+            game.toggle_cell((cell_x, cell_y))
+                .expect("Error toggling cell");
+        }
+    }
+
+    // Handle space key input
+    if is_key_pressed(KeyCode::Space) {
+        *running = !*running;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,10 +25,11 @@ async fn main() {
         if !running {
             draw_text("Click to toggle cells", 10.0, 20.0, 20.0, BLACK);
             draw_text("Spacebar to start/pause", 10.0, 40.0, 20.0, BLACK);
+            draw_text("R to reset the board", 10.0, 60.0, 20.0, BLACK);
         } else {
             game.next();
         }
-
+        std::thread::sleep(std::time::Duration::from_millis(20));
         next_frame().await;
     }
 }
@@ -71,5 +72,9 @@ fn handle_input(game: &mut Game, grid_size: f32, width: usize, height: usize, ru
     // Handle space key input
     if is_key_pressed(KeyCode::Space) {
         *running = !*running;
+    }
+    // Handle space key input
+    if is_key_pressed(KeyCode::R) {
+        game.genocide();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,14 +11,7 @@ async fn main() {
     let height = (screen_height / grid_size).ceil() as usize;
 
     // Create initial living cells
-    let mut initial_living_cells = Vec::new();
-    for x in 0..height {
-        for y in 0..width {
-            if rand::gen_range(0, 5) == 0 {
-                initial_living_cells.push((x, y));
-            }
-        }
-    }
+    let initial_living_cells = Vec::new();
 
     // Initialize the game
     let mut game = match Game::from_cells((width, height), &initial_living_cells) {
@@ -32,6 +25,8 @@ async fn main() {
     // Define grid parameters
     let horizontal_lines = height as i32;
     let vertical_lines = width as i32;
+
+    let mut running = false;
 
     loop {
         clear_background(WHITE);
@@ -55,8 +50,29 @@ async fn main() {
             draw_rectangle(x, y, grid_size, grid_size, BLACK);
         }
 
-        // Update the game state for the next frame
-        game.next();
+        // Handle mouse input
+        if is_mouse_button_pressed(MouseButton::Left) {
+            let mouse_position = mouse_position();
+            let cell_x = (mouse_position.0 / grid_size).floor() as usize;
+            let cell_y = (mouse_position.1 / grid_size).floor() as usize;
+            if cell_x < width && cell_y < height {
+                game.toggle_cell((cell_x, cell_y));
+            }
+        }
+        // Handle buttons
+        if is_key_pressed(KeyCode::Space) {
+            running = !running;
+        }
+
+        if !running {
+            draw_text("Click to toggle cells", 10.0, 20.0, 20.0, BLACK);
+            draw_text("Spacebar to start/pause", 10.0, 40.0, 20.0, BLACK);
+            if is_key_pressed(KeyCode::Space) {
+                game.next();
+            }
+        } else {
+            game.next();
+        }
 
         next_frame().await;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,8 @@ async fn main() {
 
     // Create initial living cells
     let mut initial_living_cells = Vec::new();
-    for x in 0..width {
-        for y in 0..height {
+    for x in 0..height {
+        for y in 0..width {
             if rand::gen_range(0, 5) == 0 {
                 initial_living_cells.push((x, y));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use conways_game_of_life::game::{Game, Position};
+use conways_game_of_life::game::Game;
 use macroquad::prelude::*;
 
 #[macroquad::main("Game of Life")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,8 @@ async fn main() {
             let cell_x = (mouse_position.0 / grid_size).floor() as usize;
             let cell_y = (mouse_position.1 / grid_size).floor() as usize;
             if cell_x < width && cell_y < height {
-                game.toggle_cell((cell_x, cell_y));
+                game.toggle_cell((cell_x, cell_y))
+                    .expect("Error toggling cell");
             }
         }
         // Handle buttons
@@ -66,7 +67,7 @@ async fn main() {
 
         if !running {
             draw_text("Click to toggle cells", 10.0, 20.0, 20.0, BLACK);
-            draw_text("-click to start/pause", 10.0, 40.0, 20.0, BLACK);
+            draw_text("Spacebar to start/pause", 10.0, 40.0, 20.0, BLACK);
             if is_key_pressed(KeyCode::Space) {
                 game.next();
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ async fn main() {
 
         if !running {
             draw_text("Click to toggle cells", 10.0, 20.0, 20.0, BLACK);
-            draw_text("Spacebar to start/pause", 10.0, 40.0, 20.0, BLACK);
+            draw_text("-click to start/pause", 10.0, 40.0, 20.0, BLACK);
             if is_key_pressed(KeyCode::Space) {
                 game.next();
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,17 +10,8 @@ async fn main() {
     let width = (screen_width / grid_size).ceil() as usize;
     let height = (screen_height / grid_size).ceil() as usize;
 
-    // Create initial living cells
-    let initial_living_cells = Vec::new();
-
     // Initialize the game
-    let mut game = match Game::from_cells((width, height), &initial_living_cells) {
-        Ok(game) => game,
-        Err(e) => {
-            eprintln!("Failed to initialize the game: {:?}", e);
-            return;
-        }
-    };
+    let mut game = Game::of_size((width, height));
 
     // Define grid parameters
     let horizontal_lines = height as i32;


### PR DESCRIPTION
Implements the main game loop on main.rs.

Extends the Game API with the following functions:
```rust
    pub fn from_size_and_cells(dimensions: Position, cells: &[Position],
    ) -> Result<Self, GameError> 
    pub fn of_size(dimensions: Position) -> Self 
    pub fn toggle_cell(&mut self, pos: (usize, usize)) -> Result<(), GameError>
    pub fn kill(&mut self, pos: Position) -> Result<(), GameError> 
    pub fn give_life(&mut self, pos: Position) -> Result<(), GameError> 
    pub fn kill_list(&mut self, list: &[Position]) -> Result<(), GameError> 
    pub fn give_life_list(&mut self, list: &[Position]) -> Result<(), GameError> 
    pub fn alive_cells(&self) -> &HashSet<Position> 
    pub fn dimensions(&self) -> Position 
    pub fn is_alive(&self, pos: Position) -> bool 
```

Also includes several reformats, including variable and functino renames and method abstractions, let me know if anything is hard to understand.